### PR TITLE
Restore slash command registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",
+  "scripts": {
+    "build": "tsc",
+    "test": "yarn build && node scripts/check-commands.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ryceg/Eigengrau-s-Helper.git"
@@ -22,7 +26,7 @@
     "eslint": "7.29",
     "pg": "8.6",
     "reflect-metadata": "^0.1.13",
-    "slash-create": "^3.2.3",
+    "slash-create": "^6.8.1",
     "typeorm": "^0.2.32"
   }
 }

--- a/scripts/check-commands.js
+++ b/scripts/check-commands.js
@@ -1,0 +1,26 @@
+const path = require("path")
+const { SlashCreator } = require("slash-create")
+
+async function main() {
+  const creator = new SlashCreator({
+    applicationID: "000000000000000000",
+    token: "test.token.value",
+  })
+  const commands = await creator.registerCommandsIn(
+    path.join(__dirname, "..", "dist", "commands")
+  )
+  const commandNames = commands.map((command) => command.commandName).sort()
+
+  if (commandNames.length !== 11) {
+    throw new Error(
+      `Expected 11 slash commands to load, loaded ${commandNames.length}: ${commandNames.join(", ")}`
+    )
+  }
+
+  console.log(commandNames.join("\n"))
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/src/commands/addList.ts
+++ b/src/commands/addList.ts
@@ -26,7 +26,7 @@ const commandOptionListTitle = 'list-title'
 const commandOptionListTitleDescription = "The title of the list."
 
 
-export class AddListCommand extends SlashCommand {
+export default class AddListCommand extends SlashCommand {
   constructor(creator) {
     super(creator, {
       name: "addlist",

--- a/src/commands/adjust.ts
+++ b/src/commands/adjust.ts
@@ -1,11 +1,10 @@
-import { CommandContext, SlashCommand } from "slash-create"
-import { CommandOptionType, CommandStringOption } from "slash-create/lib/constants"
+import { CommandContext, CommandOptionType, CommandStringOption, SlashCommand } from "slash-create"
 import { DiscordUtility } from "../utility/DiscordUtility"
 import { Settings } from "../entity/Settings"
 import { Member } from "../entity/Member"
 const { GUILD_ID } = require("../../config.json")
 
-export class AnarchyPostingCommand extends SlashCommand {
+export default class AnarchyPostingCommand extends SlashCommand {
   constructor(creator) {
     super(creator, {
       name: "adjust",

--- a/src/commands/finish.ts
+++ b/src/commands/finish.ts
@@ -5,7 +5,7 @@ import { Channel } from "../entity/Channel";
 import { Settings } from "../entity/Settings";
 const { GUILD_ID } = require("../../config.json");
 
-export class FinishCommand extends SlashCommand {
+export default class FinishCommand extends SlashCommand {
   constructor(creator) {
     super(creator, {
       name: "finish",

--- a/src/commands/me.ts
+++ b/src/commands/me.ts
@@ -5,7 +5,7 @@ import { DiscordUtility } from "../utility/DiscordUtility"
 import { Member } from "../entity/Member"
 const { GUILD_ID } = require("../../config.json")
 
-export class MeCommand extends SlashCommand {
+export default class MeCommand extends SlashCommand {
   constructor(creator) {
     super(creator, {
       name: "stats",

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -11,7 +11,7 @@ const newCommand = 'new'
 const customList = 'custom-list'
 const customTargetAmount = 'target-amount'
 
-export class NewCommand extends SlashCommand {
+export default class NewCommand extends SlashCommand {
   constructor(creator) {
     super(creator, {
       name: newCommand,

--- a/src/commands/pointsrate.ts
+++ b/src/commands/pointsrate.ts
@@ -8,7 +8,7 @@ import {
 import { AnyChannel } from "../entity/AnyChannel"
 const { GUILD_ID } = require("../../config.json")
 
-export class PointsRate extends SlashCommand {
+export default class PointsRate extends SlashCommand {
   constructor(creator) {
     super(creator, {
       name: "points-rate",

--- a/src/commands/rescan.ts
+++ b/src/commands/rescan.ts
@@ -11,7 +11,7 @@ const LIST_TITLE_CONTENT_REGEX = new RegExp("(?<=\\*\\*)(.*)(?=\\*\\*)")
 const LIST_INDEX_REGEX = new RegExp("^(.*)(?=\\.)")
 const CONTENT_REGEX = new RegExp("(?<=\\.)(.*)(?=$)", "s")
 
-export class RescanCommand extends SlashCommand {
+export default class RescanCommand extends SlashCommand {
   constructor(creator) {
     super(creator, {
       name: "rescan",

--- a/src/commands/target.ts
+++ b/src/commands/target.ts
@@ -7,7 +7,7 @@ import { DiscordUtility } from "../utility/DiscordUtility"
 import { ListUtility } from "../utility/ListUtility"
 const { GUILD_ID } = require("../../config.json")
 
-export class TargetCommand extends SlashCommand {
+export default class TargetCommand extends SlashCommand {
   constructor(creator) {
     super(creator, {
       name: "target",

--- a/src/commands/toggleAnarchyPosting.ts
+++ b/src/commands/toggleAnarchyPosting.ts
@@ -1,10 +1,9 @@
-import { CommandContext, SlashCommand } from "slash-create"
-import { CommandBooleanOption, CommandOptionType } from "slash-create/lib/constants"
+import { CommandBooleanOption, CommandContext, CommandOptionType, SlashCommand } from "slash-create"
 import { DiscordUtility } from "../utility/DiscordUtility"
 import { Settings } from "../entity/Settings"
 const { GUILD_ID } = require("../../config.json")
 
-export class AnarchyPostingCommand extends SlashCommand {
+export default class AnarchyPostingCommand extends SlashCommand {
   constructor(creator) {
     super(creator, {
       name: "anarchyposting",

--- a/src/commands/toggleAutoPosting.ts
+++ b/src/commands/toggleAutoPosting.ts
@@ -1,10 +1,9 @@
-import { CommandContext, SlashCommand } from "slash-create"
-import { CommandBooleanOption, CommandOptionType } from "slash-create/lib/constants"
+import { CommandBooleanOption, CommandContext, CommandOptionType, SlashCommand } from "slash-create"
 import { DiscordUtility } from "../utility/DiscordUtility"
 import { Settings } from "../entity/Settings"
 const { GUILD_ID } = require("../../config.json")
 
-export class AutoPostingCommand extends SlashCommand {
+export default class AutoPostingCommand extends SlashCommand {
   constructor(creator) {
     super(creator, {
       name: "autoposting",

--- a/src/commands/top.ts
+++ b/src/commands/top.ts
@@ -1,11 +1,10 @@
 import { CommandContext, SlashCommand } from "slash-create"
-import { CommandOptionType } from "slash-create/lib/constants"
 import { Activity } from "../entity/Activity"
 import { MessageEmbed } from "discord.js"
 import { DiscordUtility } from "../utility/DiscordUtility"
 const { GUILD_ID } = require("../../config.json")
 
-export class TopCommand extends SlashCommand {
+export default class TopCommand extends SlashCommand {
   constructor(creator) {
     super(creator, {
       name: "top",

--- a/src/entity/List.ts
+++ b/src/entity/List.ts
@@ -3,7 +3,6 @@ import { MessageEmbed, TextChannel } from "discord.js"
 import { Channel } from "./Channel"
 import { DiscordUtility } from "../utility/DiscordUtility"
 import { Settings } from "./Settings"
-import { NewCommand } from "../commands/new"
 import { ListUtility } from "../utility/ListUtility"
 const {
   FINISHED_LISTS_CHANNEL,

--- a/src/entity/PendingList.ts
+++ b/src/entity/PendingList.ts
@@ -3,7 +3,6 @@ import { MessageEmbed, TextChannel } from "discord.js"
 import { Channel } from "./Channel"
 import { DiscordUtility } from "../utility/DiscordUtility"
 import { Settings } from "./Settings"
-import { NewCommand } from "../commands/new"
 import { ListUtility } from "../utility/ListUtility"
 
 @Entity()

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,11 @@
+import { Client } from "discord.js"
+import { Connection } from "typeorm"
+
+declare global {
+  namespace NodeJS {
+    interface Global {
+      CLIENT: Client
+      CONNECTION: Connection
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,9 +52,6 @@ const creator = new SlashCreator({
   publicKey: process.env.PUBLIC_KEY,
   token: process.env.TOKEN,
 })
-creator
-  .registerCommandsIn(path.join(__dirname, "commands"))
-  .syncCommands({ deleteCommands: false })
 creator.withServer(
   new GatewayServer((handler) =>
     client.ws.on(<WSEventType>"INTERACTION_CREATE", handler)
@@ -76,6 +73,11 @@ creator.on("commandRegister", (command) =>
 creator.on("commandError", (command, error) =>
   logger.error(`Command ${command.commandName}:`, error)
 )
+
+creator
+  .registerCommandsIn(path.join(__dirname, "commands"))
+  .then(() => creator.syncCommands({ deleteCommands: false }))
+  .catch((error) => logger.error("Failed to register slash commands:", error))
 
 client.on("ready", () => {
   console.log("Ready.")

--- a/src/utility/DiscordUtility.ts
+++ b/src/utility/DiscordUtility.ts
@@ -1,5 +1,4 @@
 import { Channel, TextChannel, User } from "discord.js"
-import "../index"
 
 export class DiscordUtility {
   static async getUserFromId(id: string): Promise<User> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -52,6 +52,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@fastify/busboy@^2.0.0":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.1.1.tgz#b9da6a878a371829a0502c9b6c1c143ef6663f4d"
+  integrity sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==
+
 "@sqltools/formatter@^1.2.2":
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@sqltools/formatter/-/formatter-1.2.3.tgz#1185726610acc37317ddab11c3c7f9066966bd20"
@@ -520,10 +525,10 @@ event-target-shim@^5.0.0:
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
   integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
-eventemitter3@^4.0.7:
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
-  integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
+eventemitter3@^5.0.1:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.4.tgz#a86d66170433712dde814707ac52b5271ceb1feb"
+  integrity sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -748,11 +753,6 @@ lodash.truncate@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
-
-lodash.uniq@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
-  integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
 lru-cache@^6.0.0:
   version "6.0.0"
@@ -989,11 +989,6 @@ regexpp@^3.1.0:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
 
-require-all@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/require-all/-/require-all-3.0.0.tgz#473d49704be310115ce124f77383b1ebd8671312"
-  integrity sha1-Rz1JcEvjEBFc4ST3c4Ox69hnExI=
-
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -1058,17 +1053,15 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-slash-create@^3.2.3:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/slash-create/-/slash-create-3.3.0.tgz#af7845025d21b0134d6fd3ff8924e30eb92f0160"
-  integrity sha512-dH80fs7rVzYXxgt9thliJJaz/0GKfhMHgUOjQTgIHP5HjVf0kWjd9d774OJ1bvEoklH6xt3Nhr7pti7KgdNufg==
+slash-create@^6.8.1:
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/slash-create/-/slash-create-6.8.1.tgz#31c789486d9a43370e8ab3c551f458ddf292c574"
+  integrity sha512-5TeRw2xVHPkvO1O+J3bK/9LvU/t65mTqSId0rZHn14EuPBwZIA/f5+lajALTM1BuPt1+INC48MH/eqiVEogLBw==
   dependencies:
-    "@discordjs/collection" "^0.1.6"
-    eventemitter3 "^4.0.7"
+    eventemitter3 "^5.0.1"
     lodash.isequal "^4.5.0"
-    lodash.uniq "^4.5.0"
-    require-all "^3.0.0"
     tweetnacl "^1.0.3"
+    undici "^5.28.4"
 
 slice-ansi@^4.0.0:
   version "4.0.0"
@@ -1225,6 +1218,13 @@ typescript@^4.1.3:
   version "4.3.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
   integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+
+undici@^5.28.4:
+  version "5.29.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.29.0.tgz#419595449ae3f2cdcba3580a2e8903399bd1f5a3"
+  integrity sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==
+  dependencies:
+    "@fastify/busboy" "^2.0.0"
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
Fixes ryceg/Eigengrau-s-Essential-Establishment-Generator#669.

This updates the bot to the current `slash-create` package and fixes the command loader issues that prevented the slash commands from registering.

Changes:
- upgrades `slash-create` from v3 to v6;
- switches command modules to default exports so `registerCommandsIn(...)` can load them under slash-create v6;
- replaces private `slash-create/lib/constants` imports with public package exports;
- prevents command registration from importing `src/index.ts`, which was starting the bot/database connection while merely loading command modules;
- keeps command registration asynchronous before syncing;
- adds a small smoke test that builds the TypeScript output and asserts all 11 command modules register.

Verification:
```sh
yarn test
mise x node@16 -- corepack yarn test
git diff --check
```

Both test runs registered all commands:
```text
addlist
adjust
anarchyposting
autoposting
finish
new
points-rate
rescan
stats
target
top
```